### PR TITLE
Update validations to disallow addresses outside our postal codes

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -21,3 +21,5 @@
 
 en:
   hello: "Hello world"
+  spree:
+    unsupported_delivery_location: "Delivery is not available to this location"

--- a/db/default/spree/zones.rb
+++ b/db/default/spree/zones.rb
@@ -45,6 +45,8 @@ regions = [
   },
 ]
 
+usa = Spree::Country.find_by(iso: 'US') || Spree::Country.default
+
 regions.each do |region|
   ActiveRecord::Base.transaction do
     zone = Spree::Zone.find_or_create_by!(name: region[:name]) do |s|
@@ -53,7 +55,7 @@ regions.each do |region|
     end
 
     region[:postal_codes].map do |p|
-      postal_code = Spree::PostalCode.find_or_create_by!(value: p, country: Spree::Country.default)
+      postal_code = Spree::PostalCode.find_or_create_by!(value: p, country: usa)
       zone.zone_members.create!(zoneable: postal_code)
     end
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -174,7 +174,7 @@ dish.properties += [
   Spree::Property.find_or_create_by!(name: 'sidebar', presentation: 'Sidebar'),
 ]
 
-usa = Spree::Country.find_by(iso: 'US') || Spree::Country.first
+usa = Spree::Country.find_by(iso: 'US') || Spree::Country.default
 
 # Default stock location to hold stocks of products
 Spree::StockLocation.find_or_create_by!(name: 'Default') do |s|
@@ -204,10 +204,10 @@ delivery_windows.each do |d|
       preferred_currency: d[:window][:currency],
     })
     d[:zones].each do |z|
-      sm.shipping_method_zones.create!(zone: z)
+      sm.shipping_method_zones.build(zone: z)
     end
   end
-  shipping_method.delivery_windows = [Spree::DeliveryWindow.create!(d[:window])]
+  Spree::DeliveryWindow.create!(d[:window].merge(shipping_method: shipping_method))
 end
 
 # Stripe Payment Gateway

--- a/spec/models/spree/postal_code_spec.rb
+++ b/spec/models/spree/postal_code_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Spree::PostalCode, type: :model do
     pending "value is required"
     pending "country is required"
     pending "runs postal_code_validate"
-    pending "runs us_restrict_digits_validate"
+    pending "restrict US postal codes to 5 digits"
   end
 
   describe "instance methods" do


### PR DESCRIPTION
This blocks checkout at the "address" step with the error message "Delivery is not available to this location" when the address's zip code is not already present in our database.
