### PR TITLE
Compile assets in Production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,7 +29,7 @@ Rails.application.configure do
   # config.assets.css_compressor = :sass
 
   # Do not fallback to assets pipeline if a precompiled asset is missed.
-  config.assets.compile = false
+  config.assets.compile = true
 
   # Asset digests allow you to set far-future HTTP expiration dates on all assets,
   # yet still be able to expire them through the digest params.


### PR DESCRIPTION
Rails.application.assets is nil in production
https://github.com/rails/sprockets-rails/issues/237

Rails.application.assets is Nil on Heroku after upgrade sprockets-rails to 3.0.0
http://stackoverflow.com/questions/34380753/rails-application-assets-is-nil-on-heroku-after-upgrade-sprockets-rails-to-3-0-0

fixes #240
