### PR TITLE
Create SubscriptionOrderManager to generate subscription selections

### DIFF
--- a/app/lib/meal_selector.rb
+++ b/app/lib/meal_selector.rb
@@ -4,10 +4,13 @@ class MealSelector
   # Initializes a meal selector to create a set of selections matching all preferences and
   # subscriptions from available meals. It relates subscriptions to meal preferences by
   # the user_id field of each. Available meals must be a hash of meal => available stock.
-  def initialize(meal_preferences, subscriptions=[], available_meals={})
-    @meal_preferences = meal_preferences.sort_by { |mp| mp.diet_count - mp.allergen_count }
+  def initialize(subscriptions=[], available_meals={})
     @subscriptions = subscriptions.index_by(&:user_id)
     @available_meals = available_meals
+  end
+
+  def meal_preferences
+    Spree::MealPreference.where(user_id: @subscriptions.keys).sort_by { |mp| mp.diet_count - mp.allergen_count }
   end
 
   def selections(no_repeats_last_n_orders=3)
@@ -19,7 +22,7 @@ class MealSelector
     def generate_selections(last_n)
       selections = {}
 
-      @meal_preferences.each do |meal_preference|
+      meal_preferences.each do |meal_preference|
         # Verify subscription is active
         subscription = @subscriptions[meal_preference.user_id]
         next unless subscription.present?

--- a/app/lib/subscription_order_manager.rb
+++ b/app/lib/subscription_order_manager.rb
@@ -28,11 +28,7 @@ class SubscriptionOrderManager
 
   private
 
-  def meal_preferences(subscriptions)
-    Spree::MealPreference.where(user_id: subscriptions.pluck(:user_id))
-  end
-
   def selections(subscriptions)
-    MealSelector.new(meal_preferences(subscriptions), subscriptions, @available_meals).selections
+    MealSelector.new(subscriptions, @available_meals).selections
   end
 end

--- a/spec/lib/meal_selector_spec.rb
+++ b/spec/lib/meal_selector_spec.rb
@@ -14,8 +14,16 @@ RSpec.describe MealSelector, subscription_data: true do
     no_shellfish_mp,
     default_mp,
   ]}
+  let(:delivery_days) { Spree::MealSubscription.delivery_days.keys }
+  let(:subscriptions) {
+    subscriptions = []
+    meal_preferences_in_order.each_with_index { |mp, i|
+      subscriptions << FactoryGirl.create(:meal_subscription, user: mp.user, delivery_day: delivery_days[i % delivery_days.size])
+    }
+    subscriptions
+  }
 
-  let(:meal_selector) { described_class.new(meal_preferences) }
+  let(:meal_selector) { described_class.new(subscriptions.shuffle) }
 
   it 'orders meal preferences from most to least constrained' do
     # Verify preconditions
@@ -26,14 +34,6 @@ RSpec.describe MealSelector, subscription_data: true do
   end
 
   describe 'with subscriptions' do
-    let(:delivery_days) { Spree::MealSubscription.delivery_days.keys }
-    let(:subscriptions) {
-      subscriptions = []
-      meal_preferences_in_order.each_with_index { |mp, i|
-        subscriptions << FactoryGirl.create(:meal_subscription, user: mp.user, delivery_day: delivery_days[i % delivery_days.size])
-      }
-      subscriptions
-    }
     let(:available_meals) {
       n = meal_preferences.size
       {
@@ -43,7 +43,7 @@ RSpec.describe MealSelector, subscription_data: true do
         braised_veg => n,
       }
     }
-    let(:meal_selector) { described_class.new(meal_preferences, subscriptions, available_meals) }
+    let(:meal_selector) { described_class.new(subscriptions, available_meals) }
 
     it "returns selections matching the subscribers' meal preferences" do
       expect(meal_selector.selections[subscriptions[0]]).to eql([braised_veg, nil])


### PR DESCRIPTION
Fire up a console on the production application:

``` console
$ heroku run bin/rails console -a din-marketplace
```

Generate and print out subscription selections:

``` ruby
# After orders for the preceding week have been created for Monday subscribers, create the
# subscription manager with stock for Monday.
# Use exact name from admin products.
# Sort products in order of desired recommendation.
mgr = SubscriptionOrderManager.from_meal_names({
  "Calabrian Antipasti" => 15,
  "Seared Idaho Trout" => 25,
  "Chitarra alla Puttanesca & Sturgeon Conserva" => 20,
  "A16’s Monday Meatballs" => 15,
  "Cornmeal Cakes with Roasted Broccoli Rabe" => 25,
  "Little Gem Salad with Farm Egg" => 25,
  "Coconut Turmeric Curry" => 5,
  "Ginger Lemongrass Chicken" => 10,
  "Maranella Pinsa & Insalata Mista" => 10,
  "Margherita Pinsa & Rapette Salad" => 10,
})
# Generate and print selections from available meals for Monday subscribers.
mgr.print_selections(Spree::MealSubscription.monday)
```

Repeat for Tuesday by creating a new manager after Tuesday orders have been placed for the preceding week, and hand in the Tuesday subscriptions: `Spree::MealSubscription.tuesday`
